### PR TITLE
Buttons: set HOME wake key default as disabled [1/2]

### DIFF
--- a/res/xml/button_settings.xml
+++ b/res/xml/button_settings.xml
@@ -60,7 +60,7 @@
         <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
             android:key="home_wake_screen"
             android:title="@string/button_wake_title"
-            android:defaultValue="true" />
+            android:defaultValue="false" />
 
         <SwitchPreference
             android:key="home_answer_call"


### PR DESCRIPTION
* This should really be opt-in as needed by the user,
  not forced upon by default. This matches other wake
  key defaults
* With these settings removed by overlay, defaulting
  as true they conflict with kernel features like s2w
  on capacitive Key devices.

Change-Id: Ibdd580fd0d0ed268fbd504f82db8e47901a3741d