### PR TITLE
Utils: Fix isPackageInstalled

### DIFF
--- a/src/com/android/settings/DevelopmentSettings.java
+++ b/src/com/android/settings/DevelopmentSettings.java
@@ -349,7 +349,7 @@ public class DevelopmentSettings extends SettingsPreferenceFragment
             disableForUser(mQuickBoot);
         }
 
-        if (!Utils.isPackageInstalled(getActivity(), QUICKBOOT_PACKAGE_NAME)) {
+        if (!Utils.isPackageInstalled(getActivity(), QUICKBOOT_PACKAGE_NAME, false)) {
             removePreference(mQuickBoot);
         }
 

--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -1214,7 +1214,7 @@ public class SettingsActivity extends Activity
                         removeTile = true;
                     }
                 } else if (id == R.id.voice_wakeup_settings) {
-                    if (!Utils.isPackageInstalled(this, VOICE_WAKEUP_PACKAGE_NAME)) {
+                    if (!Utils.isPackageInstalled(this, VOICE_WAKEUP_PACKAGE_NAME, false)) {
                         removeTile = true;
                     }
                 } else if (id == R.id.performance_settings) {

--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -1070,11 +1070,11 @@ public final class Utils {
         return sb.toString();
     }
 
-    public static boolean isPackageInstalled(Context context, String pkg) {
+    public static boolean isPackageInstalled(Context context, String pkg, boolean ignoreState) {
         if (pkg != null) {
             try {
                 PackageInfo pi = context.getPackageManager().getPackageInfo(pkg, 0);
-                if (!pi.applicationInfo.enabled) {
+                if (!pi.applicationInfo.enabled && !ignoreState) {
                     return false;
                 }
             } catch (NameNotFoundException e) {
@@ -1083,5 +1083,9 @@ public final class Utils {
         }
 
         return true;
+    }
+
+    public static boolean isPackageInstalled(Context context, String pkg) {
+        return isPackageInstalled(context, pkg, true);
     }
 }


### PR DESCRIPTION
The original implementation ignored the package state, and this is
necessary for enable/disable toggles like the one used by Terminal.

Bring the original behavior back, and make the new one optional

Change-Id: I7a71f26322f4fa76dc2ae8664b3065bd6719cf11