### PR TITLE
Fix bug on QS selection preference.

### DIFF
--- a/src/com/android/settings/cyanogenmod/qs/DraggableGridView.java
+++ b/src/com/android/settings/cyanogenmod/qs/DraggableGridView.java
@@ -229,7 +229,7 @@ public class DraggableGridView extends ViewGroup implements
             }
         }
 
-        if (index > getChildCount()) {
+        if (index >= getChildCount()) {
             return -1;
         }
         return index;


### PR DESCRIPTION
DraggableGridView allows you to put a tile after the Add/Delete one, causing buggy behaviour.

Change-Id: Id0c61b188ce72d3bf371fd906ecd47c41c7ae528